### PR TITLE
Add links to DESCRIPTION

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -25,5 +25,7 @@ Suggests:
 RoxygenNote: 7.2.1
 Roxygen: list(markdown = TRUE)
 VignetteBuilder: knitr
+URL: https://shwilks.github.io/r3js/, https://github.com/shwilks/r3js
+BugReports: https://github.com/shwilks/r3js/issues
 Depends: 
     R (>= 2.10)


### PR DESCRIPTION
Make the repo more easy to discover.

You may consider adding the link in the About section on the gh homepage.
![image](https://github.com/shwilks/r3js/assets/52606734/ddaf3d3c-502c-4053-b905-74e9da7c5d26)
